### PR TITLE
Removed property 'compatibilities'

### DIFF
--- a/cfecs/__init__.py
+++ b/cfecs/__init__.py
@@ -164,8 +164,6 @@ def update_service(cluster_name, service_name, ecs=None, **kwargs):
     task_definition_desc = ecs.describe_task_definition(taskDefinition = current_task_def_arn)
     task_definition = task_definition_desc['taskDefinition']
 
-    log.info(task_definition)
-    
     keys_to_remove = ["status", "taskDefinitionArn", "requiresAttributes", "revision", "compatibilities"]
     for k in keys_to_remove:
         task_definition.pop(k, None)

--- a/cfecs/__init__.py
+++ b/cfecs/__init__.py
@@ -163,13 +163,17 @@ def update_service(cluster_name, service_name, ecs=None, **kwargs):
 
     task_definition_desc = ecs.describe_task_definition(taskDefinition = current_task_def_arn)
     task_definition = task_definition_desc['taskDefinition']
-    keys_to_remove = ["status", "taskDefinitionArn", "requiresAttributes", "revision"]
+
+    log.info(task_definition)
+    
+    keys_to_remove = ["status", "taskDefinitionArn", "requiresAttributes", "revision", "compatibilities"]
     for k in keys_to_remove:
         task_definition.pop(k, None)
 
     image_name = kwargs.get('image_name')
     new_image_tag = kwargs.get('image_tag')
     new_image_name_tag = '{}:{}'.format(image_name, new_image_tag)
+    
     if image_name and new_image_tag:
         _found = False
         for c in task_definition['containerDefinitions']:
@@ -192,8 +196,9 @@ def update_service(cluster_name, service_name, ecs=None, **kwargs):
         'service': service_name,
         'desiredCount': service['desiredCount'],
         'taskDefinition': new_task_def_arn,
-        'deploymentConfiguration': service['deploymentConfiguration']
+        'deploymentConfiguration': service['deploymentConfiguration'],
     }
+
     log.info("Updating Service: {}".format(pprint.pformat(update_service_params)))
     response = ecs.update_service(**update_service_params)
     if not response or not response.get('service') or not response.get('ResponseMetadata') or response.get('ResponseMetadata').get('HTTPStatusCode') > 299:

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -1,9 +1,0 @@
-version: '1.0'
-steps:
-  BuildingDockerImage:
-    title: Building Docker Image
-    type: build
-    image_name: timeideros/cf-deploy-ecs
-    working_directory: ./
-    dockerfile: Dockerfile
-    tag: '${{CF_BUILD_TIMESTAMP}}'

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -1,11 +1,9 @@
 version: '1.0'
-
 steps:
-  build-step:
+  BuildingDockerImage:
+    title: Building Docker Image
     type: build
-    image-name: codefresh/cf-deploy-ecs
-
-  push to registry:
-    type: push
-    candidate: ${{build-step}}
-    tag: ${{CF_BRANCH}}
+    image_name: timeideros/cf-deploy-ecs
+    working_directory: ./
+    dockerfile: Dockerfile
+    tag: '${{CF_BUILD_TIMESTAMP}}'


### PR DESCRIPTION
The property 'compatibilites' causes error when applying the service update on a fargate task

ERROR: Parameter validation failed:
Unknown parameter in input: "compatibilities", must be one of: family, taskRoleArn, executionRoleArn, networkMode, containerDefinitions, volumes, placementConstraints, requiresCompatibilities, cpu, memory
